### PR TITLE
fix: hashmap.huff hashing pattern changed to solidity pattern

### DIFF
--- a/src/data-structures/Hashmap.huff
+++ b/src/data-structures/Hashmap.huff
@@ -26,7 +26,7 @@
     <mem_ptr>           // [<mem_ptr>, key2]
     mstore              // []
 
-    // Hash the data, generating a key.
+    // Hash the data, generating a slot.
     0x40        // [64]
     <mem_ptr>   // [<mem_ptr>, 64]
     sha3        // [key]

--- a/src/data-structures/Hashmap.huff
+++ b/src/data-structures/Hashmap.huff
@@ -21,15 +21,15 @@
 #define macro GET_SLOT_FROM_KEYS(mem_ptr) = takes(2) returns (1) {
     // Input stack: [slot, key]
     // Load the data into memory.
-    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, slot, key2]
-    mstore              // [key2]
-    <mem_ptr>           // [<mem_ptr>, key2]
+    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, slot, key]
+    mstore              // [key]
+    <mem_ptr>           // [<mem_ptr>, key]
     mstore              // []
 
     // Hash the data, generating a slot.
     0x40        // [64]
     <mem_ptr>   // [<mem_ptr>, 64]
-    sha3        // [key]
+    sha3        // [slot]
 }
 
 /// @notice Calculate the slot from two keys

--- a/src/data-structures/Hashmap.huff
+++ b/src/data-structures/Hashmap.huff
@@ -19,7 +19,7 @@
 
 /// @notice Given two keys (ie a slot and a key), hash them together, generating a slot for a secondary hashmap.
 #define macro GET_SLOT_FROM_KEYS(mem_ptr) = takes(2) returns (1) {
-    // Input stack: [slot, key2]
+    // Input stack: [slot, key]
     // Load the data into memory.
     <mem_ptr> 0x20 add  // [<mem_ptr> + 32, slot, key2]
     mstore              // [key2]

--- a/src/data-structures/Hashmap.huff
+++ b/src/data-structures/Hashmap.huff
@@ -17,14 +17,13 @@
     sha3                // [slot]
 }
 
-/// @notice Given two keys (ie an address and a number), hash them together, generating a slot for a secondary hashmap.
-///         This should only be used if you have multiple maps in your contract.
+/// @notice Given two keys (ie a slot and a key), hash them together, generating a slot for a secondary hashmap.
 #define macro GET_SLOT_FROM_KEYS(mem_ptr) = takes(2) returns (1) {
-    // Input stack: [key1, key2]
+    // Input stack: [slot, key2]
     // Load the data into memory.
-    <mem_ptr>           // [<mem_ptr>, key1, key2]
+    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, slot, key2]
     mstore              // [key2]
-    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, key2]
+    <mem_ptr>           // [<mem_ptr>, key2]
     mstore              // []
 
     // Hash the data, generating a key.
@@ -37,42 +36,41 @@
 #define macro GET_SLOT_FROM_KEYS_2D(mem_ptr) = takes(3) returns (1) {
     // Input stack: [slot, key1, key2]
     // Load the data into memory
-    <mem_ptr>           // [<mem_ptr>, slot, key1, key2]
+    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, slot, key1, key2]
     mstore              // [key1, key2]
 
     // next byte
-    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, key1, key2]
+    <mem_ptr>           // [<mem_ptr>, key1, key2]
     mstore              // [key2]
 
     0x40                // [0x40, key2]
     <mem_ptr>           // [<mem_ptr>, 0x40, key2]
-    sha3                // [slot1, key2]
+    sha3                // [hash, key2]
 
     // concat the two keys
-    <mem_ptr> 0x20 add  // [<mem_ptr> + 0x20, slot1, key2] put slot1 in memory
+    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, hash, key2] put hash in memory
     mstore              // [key2]
 
     // next byte
     <mem_ptr>           // [<mem_ptr>, key2]
     mstore              // []
 
-    // Hash the data, generating a key.
+    // Hash the data, generating a slot.
     0x40                // [0x40]
     <mem_ptr>           // [<mem_ptr>, 0x40]
-    sha3                // [key]
+    sha3                // [slot]
 }
 
 /// @notice Calculate the slot from three keys
 #define macro GET_SLOT_FROM_KEYS_3D(mem_ptr) = takes(4) returns (1) {
     // Input stack: [slot, key1, key2, key3]
     // Load the data into memory
-    <mem_ptr>           // [<mem_ptr>, slot, key1, key2, key3]
-    mstore              // [key1, key2, key3]
+    <mem_ptr> 0x20 add     // [<mem_ptr> + 32, slot, key1, key2, key3]
+    swap1 dup2             // [<mem_ptr> + 32, slot, <mem_ptr> + 32, key1, key2, key3]
+    mstore                 // [<mem_ptr> + 32, key1, key2, key3]
 
-    // next byte
-    <mem_ptr> 0x20 add  // [<mem_ptr> + 32, key1, key2, key3]
-    swap1 dup2          // [<mem_ptr> + 32, key1, <mem_ptr> + 32, key2, key3]
-    mstore              // [<mem_ptr> + 32, key2, key3]
+    swap1 <mem_ptr>      // [<mem_ptr>, key1, <mem_ptr> + 32, key2, key3]
+    mstore               // [<mem_ptr> + 32, key2, key3]
 
     0x40                // [0x40, <mem_ptr> + 32, key2, key3]
     <mem_ptr>           // [<mem_ptr>, 0x40, <mem_ptr> + 32, key2, key3]


### PR DESCRIPTION
This changes the pattern of hashing for slots in `Hashmap.huff` to match that of how solidity lang handles mappings.

`GET_SLOT_FROM_KEYS()` function uses `sha3(slot . key)` against `sha3(key . slot)` used in solidity,
`GET_SLOT_FROM_KEYS_2D()` function uses `sha3(sha3(slot . key1) . key2)` against `sha3(key2 . sha3(key1 . slot)` used in solidity and 
`GET_SLOT_FROM_KEYS_3D()` function uses `sha3(key3 . sha3(key2 . sha3(slot . key1)))` against `sha3(key3 . sha3(key2 . sha3(key1 . slot)))` used in solidity.