### PR TITLE
fix: erc20-test

### DIFF
--- a/test/tokens/ERC20.t.sol
+++ b/test/tokens/ERC20.t.sol
@@ -209,7 +209,7 @@ contract ERC20Test is Test {
 
         token.mint(from, 1e18);
 
-        vm.prank(from);
+        vm.startPrank(from);
         token.approve(address(this), type(uint256).max);
         vm.stopPrank();
 


### PR DESCRIPTION
Fixes test caused by missing `startPrank` clause