### PR TITLE
Optimization: Removed double `iszero` before `jumpi`

### DIFF
--- a/src/tokens/ERC1155.huff
+++ b/src/tokens/ERC1155.huff
@@ -764,7 +764,7 @@
         // parameter is needed when calling the onReceive function on the receiving contract, as safeTransferFrom already has an extra address parameter no 
         // resizing of dynamic data pointers are required.
         // We can check if this is coming from mint or safeTransferFrom by checking if the from value on the stack is the zero address or not
-        dup4 iszero iszero skipResize jumpi
+        dup4 skipResize jumpi
 
         // update location of the bytes calldata
         0xa0 0xa4 mstore
@@ -817,7 +817,7 @@
     // [to, from, &ids]
 
     // If being sent by a contract then do contract code check, no need to check for zero address and contract as it would not have code
-    dup1 extcodesize iszero iszero  // [!(codesize(to)), to, from, &ids]
+    dup1 extcodesize                // [codesize(to), to, from, &ids]
     isContract jumpi                // [to, from, &ids]
 
     // check is sending to the zero address, if so revert, otherwise continue
@@ -848,7 +848,7 @@
 
     // We can skip this rezise if we are transferring as we can assume the offsets are in the corrrect places, due to the increased address input parameter
     // We can tell if we are transferring as the from parameter on the stack will NOT be zero
-    dup4 iszero iszero skipResize jumpi
+    dup4 skipResize jumpi
 
     // increase the dyn pointer balances by 0x20 for each dynamic type, this is due to the introduction of the from value in the call
     0x20                                    // [0x20, selector, cds, to, from, &ids]

--- a/src/tokens/ERC721.huff
+++ b/src/tokens/ERC721.huff
@@ -193,7 +193,7 @@
 
     // Check token ownership
     [OWNER_LOCATION] LOAD_ELEMENT_FROM_KEYS(0x00)   // [owner, from (0x00), to, tokenId]
-    iszero iszero unauthorized jumpi
+    unauthorized jumpi
 
     // Give tokens to the recipient.
     TRANSFER_GIVE_TO()                              // [from (0x00), to, tokenId]
@@ -497,7 +497,7 @@
     cont:
 
     // If to === address(0) revert with "INVALID_RECIPIENT"
-    dup2 iszero iszero continue jumpi               // [from, to, tokenId]
+    dup2 continue jumpi                             // [from, to, tokenId]
     INVALID_RECIPIENT(0x00)
     continue:
 

--- a/src/utils/Calls.huff
+++ b/src/utils/Calls.huff
@@ -103,7 +103,7 @@
     CALL(0x01, 0x00, 0x01, 0x00, 0x00, 0x04, 0xFFFFFFFF)     // [success, 0xba5ed]
 
     // Revert if call is unsuccessful
-    iszero iszero cont jumpi
+    cont jumpi
     0x00 dup1 revert
     cont:
 
@@ -125,7 +125,7 @@
     STATICCALL(0x01, 0x00, 0x01, 0x00, 0x04, 0xFFFFFFFF)     // [success, 0xba5ed]
 
     // Revert if call is unsuccessful
-    iszero iszero cont jumpi
+    cont jumpi
     0x00 dup1 revert
     cont:
 

--- a/src/utils/ERC20Transfer.huff
+++ b/src/utils/ERC20Transfer.huff
@@ -27,7 +27,6 @@
     gas                         // [gas, to, value, args_offset, args_size, ret_offset, ret_size, acct_addr, amount, getter_addr]
     call                        // [successs, acct_addr, amount, getter_addr]
 
-    iszero iszero               // [success, acct_addr, amount, getter_addr]
     transfer_success jumpi      // [acct_addr, amount, getter_addr]
     0x00 dup1 revert            // [] - Call failed, revert
 

--- a/src/utils/ERC20Transfer.huff
+++ b/src/utils/ERC20Transfer.huff
@@ -25,7 +25,7 @@
     dup3                        // [value, args_offset, args_size, ret_offset, ret_size, acct_addr, amount, getter_addr]
     dup8                        // [to, value, args_offset, args_size, ret_offset, ret_size, acct_addr, amount, getter_addr]
     gas                         // [gas, to, value, args_offset, args_size, ret_offset, ret_size, acct_addr, amount, getter_addr]
-    call                        // [successs, acct_addr, amount, getter_addr]
+    call                        // [success, acct_addr, amount, getter_addr]
 
     transfer_success jumpi      // [acct_addr, amount, getter_addr]
     0x00 dup1 revert            // [] - Call failed, revert

--- a/src/utils/Refunded.huff
+++ b/src/utils/Refunded.huff
@@ -52,7 +52,7 @@
     origin                              // [to, value, argOffset, argSize, retOffset, retSize]
     gas                                 // [gas, to, value, argOffset, argSize, retOffset, retSize]
     call
-    iszero iszero __Refund_Successful__j jumpi
+    __Refund_Successful__j jumpi
         0x00 dup1 revert
 
     // The refund was successful!

--- a/src/utils/Refunded.huff
+++ b/src/utils/Refunded.huff
@@ -51,7 +51,7 @@
     swap4                               // [value, argOffset, argSize, retOffset, retSize]
     origin                              // [to, value, argOffset, argSize, retOffset, retSize]
     gas                                 // [gas, to, value, argOffset, argSize, retOffset, retSize]
-    call
+    call                                // [success]
     __Refund_Successful__j jumpi
         0x00 dup1 revert
 

--- a/src/utils/SSTORE2.huff
+++ b/src/utils/SSTORE2.huff
@@ -29,7 +29,7 @@
     create                            // [address, &_data]
 
     // Check that the address is non-zero
-    dup1 iszero iszero success jumpi  // [address, &_data]
+    dup1 success jumpi                // [address, &_data]
     CREATE_FAILED(0x00)
     success:
 

--- a/test/tokens/mocks/ERC4626Wrappers.huff
+++ b/test/tokens/mocks/ERC4626Wrappers.huff
@@ -63,7 +63,7 @@
     call                            // [success, asset]
 
     // Verify the call succeeded
-    iszero iszero success jumpi     // [asset]
+    success jumpi                   // [asset]
     0x00 dup1 revert                // []
     success:
 

--- a/test/utils/mocks/CallWrappers.huff
+++ b/test/utils/mocks/CallWrappers.huff
@@ -11,7 +11,7 @@
     CALL(0x01, 0x00, 0x01, 0x00, 0x00, 0x04, 0xFFFFFFFF)     // [success, 0xba5ed]
 
     // Revert if call is unsuccessful
-    iszero iszero cont jumpi
+    cont jumpi
     0x00 dup1 revert
     cont:
 
@@ -34,7 +34,7 @@
     STATICCALL(0x01, 0x00, 0x01, 0x00, 0x04, 0xFFFFFFFF)     // [success, 0xba5ed]
 
     // Revert if call is unsuccessful
-    iszero iszero cont jumpi
+    cont jumpi
     0x00 dup1 revert
     cont:
 

--- a/test/utils/mocks/EthersWrappers.huff
+++ b/test/utils/mocks/EthersWrappers.huff
@@ -15,7 +15,7 @@
         0x00 dup1 revert
 
     non_payable_jump:
-        callvalue iszero iszero reverts jumpi
+        callvalue reverts jumpi
     payable_jump:
         balance 0x00 mstore
         0x20 0x00 return


### PR DESCRIPTION
using `iszero` twice before `jumpi` is unnecessary as `jumpi` is compares between non-zero and zero (if !0 -> true), and not between 1 and 0 (if 1 -> true, else -> false).

https://www.evm.codes/#57?fork=shanghai